### PR TITLE
cer 값에 따른 결과 리턴 방식 변경

### DIFF
--- a/app/src/main/java/com/mask/api/domain/voice/api/VoiceController.java
+++ b/app/src/main/java/com/mask/api/domain/voice/api/VoiceController.java
@@ -17,8 +17,8 @@ public class VoiceController {
 
 
     @PostMapping("/")
-    public ResponseEntity<?> getAudioFile(@ModelAttribute MultipartFile audioFile) {
-        return voiceService.getAudioFile(audioFile);
+    public ResponseEntity<?> getAudioFile(@ModelAttribute MultipartFile audioFile, String answer) {
+        return voiceService.getAudioFile(audioFile, answer);
     }
 
 

--- a/app/src/main/java/com/mask/api/domain/voice/dto/ScoreDto.java
+++ b/app/src/main/java/com/mask/api/domain/voice/dto/ScoreDto.java
@@ -1,0 +1,12 @@
+package com.mask.api.domain.voice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ScoreDto {
+    private int result;
+}

--- a/app/src/main/java/com/mask/api/domain/voice/dto/TestResultDto.java
+++ b/app/src/main/java/com/mask/api/domain/voice/dto/TestResultDto.java
@@ -1,0 +1,16 @@
+package com.mask.api.domain.voice.dto;
+
+import lombok.*;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class TestResultDto {
+
+    private Double cer;
+    private String recognized_text;
+
+}

--- a/app/src/main/java/com/mask/api/domain/voice/service/VoiceService.java
+++ b/app/src/main/java/com/mask/api/domain/voice/service/VoiceService.java
@@ -1,16 +1,14 @@
 package com.mask.api.domain.voice.service;
 
+import com.mask.api.domain.voice.dto.ScoreDto;
+import com.mask.api.domain.voice.dto.TestResultDto;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.util.Objects;
 
 
@@ -20,33 +18,36 @@ public class VoiceService {
     @Value("${spring.ai.url}")
     public String url;
 
-    public ResponseEntity<?> getAudioFile(MultipartFile audioFile) {
+    public ResponseEntity<?> getAudioFile(MultipartFile audioFile, String answer) {
 
         var headers = new HttpHeaders();
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
 
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
 
-        body.add("audio_file", new FileSystemResource(convert(audioFile)));
-        body.add("answer", "sample.wav");
+        body.add("audio_file", audioFile.getResource());
+        body.add("answer", answer);
 
-        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
         HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
         RestTemplate restTemplate = new RestTemplate();
 
-        return restTemplate.exchange(url, HttpMethod.POST, requestEntity, String.class);
+        var testResult = restTemplate.exchange(url, HttpMethod.POST, requestEntity, TestResultDto.class);
+        Double cer = Objects.requireNonNull(testResult.getBody()).getCer();
+        int score = getScore(cer);
+        ScoreDto result = ScoreDto.builder().result(score).build();
+
+        return ResponseEntity.status(HttpStatus.OK).body(result);
 
     }
-    public static File convert(MultipartFile file) {
-        File convFile = new File(Objects.requireNonNull(file.getOriginalFilename()));
-        try {
-            convFile.createNewFile();
-            FileOutputStream fos = new FileOutputStream(convFile);
-            fos.write(file.getBytes());
-            fos.close();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return convFile;
+
+    private int getScore(Double cer) {
+        if(cer < 20)
+            return 1;
+        else if(cer < 40)
+            return 2;
+        else if(cer < 60)
+            return 3;
+        return 4;
     }
+
 }


### PR DESCRIPTION
## Summary
1. cer 값에 따른 결과 리턴 방식 변경
2. 음성 파일과 정답지를 같이 넘겨 받는 방식으로 변경
3. API서버에서 AI 서버로 넘길 때, 음성 파일이 저장되는 문제 수정
## Describe your changes
1. https://www.notion.so/API-e577c2449bbe4fb78efe6119ab84dc0d?p=568b8e2609f94c0cbd0f085951730650&pm=s
cer < 20 ->  1
 cer < 40 -> 2
 cer < 60 ->  3
cer >= 60 -> 4

2. cer 계산할 때, answer가 필요한데, 이 때, 매번 DB에서 찾아오는 것보다 front에서 넘겨주는 방식이 낫다고 판단

3. 파일 저장하고, FileResource 객체를 넘겨주는 방식 에서 File.Resource로 바로 데이터 접근하는 방식으로 변경


## Issue number and link
#18 
## PR CheckList
- [ ] Tests for the changes have been added (for bug fixes / features)